### PR TITLE
Bump confluent-flink-table-api-python-plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <properties>
         <flink.version>1.20.0</flink.version>
-        <confluent-plugin.version>1.20-42</confluent-plugin.version>
+        <confluent-plugin.version>1.20-48</confluent-plugin.version>
         <target.java.version>11</target.java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>${target.java.version}</maven.compiler.source>


### PR DESCRIPTION
This version bump fixes an issue where clients were unable to use the library if connecting via PrivateLink.