### PR TITLE
docs: fix typo in section for loading settings from environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ java -jar my-table-program.jar
 
 In code call:
 ```java
-ConfluentSettings settings = ConfluentSettingsfromGlobalVariables();
+ConfluentSettings settings = ConfluentSettings.fromGlobalVariables();
 ```
 
 A path to a properties file can also be specified by setting the environment variable `FLINK_PROPERTIES`.


### PR DESCRIPTION
Just something I noticed when working through the README.