### PR TITLE
Add examples for local testing and CI/CD lifecycle management

### DIFF
--- a/.github/workflows-examples/deploy.yml
+++ b/.github/workflows-examples/deploy.yml
@@ -53,7 +53,7 @@ jobs:
         # pipeline restarts from its configured source offsets without resuming prior state
         # (see the README CI/CD section).
         run: >
-          java -jar target/flink-table-api-java-examples-1.0.jar
+          java -cp target/flink-table-api-java-examples-1.0.jar io.confluent.flink.examples.table.Example_08_IntegrationAndDeployment
           --statement-name "$STATEMENT_NAME"
           --application-name "$APPLICATION_NAME"
           --sql.current-catalog "$TARGET_CATALOG"
@@ -64,6 +64,6 @@ jobs:
         # Submitting a background statement returns once Confluent Cloud accepts it, so
         # list reports the statement and its phase for visibility in the log.
         run: >
-          java -jar target/flink-table-api-java-examples-1.0.jar
+          java -cp target/flink-table-api-java-examples-1.0.jar io.confluent.flink.examples.table.Example_08_IntegrationAndDeployment
           list
           --application-name "$APPLICATION_NAME"

--- a/.github/workflows-examples/deploy.yml
+++ b/.github/workflows-examples/deploy.yml
@@ -5,6 +5,11 @@
 # required secrets.
 name: Deploy Table API Program
 
+# Show what this pipeline deploys in the runs list. run-name can only read the github and inputs
+# contexts, not env, so the application and statement names are repeated here; keep them in sync
+# with APPLICATION_NAME / STATEMENT_NAME below.
+run-name: "Deploy marketplace-analytics / vendors-per-brand"
+
 on:
   # Choose the trigger(s) that fit your deployment strategy. This template can be run
   # manually from the GitHub Actions UI; uncomment the others to deploy automatically,

--- a/.github/workflows-examples/deploy.yml
+++ b/.github/workflows-examples/deploy.yml
@@ -1,0 +1,69 @@
+# EXAMPLE WORKFLOW - copy this file to .github/workflows/ in your own repository.
+# It lives in workflows-examples/ because this examples repository does not deploy to a
+# real Confluent Cloud environment. It tests, deploys Example_08_IntegrationAndDeployment,
+# then lists the result. See the README's CI/CD section for the deployment model and the
+# required secrets.
+name: Deploy Table API Program
+
+on:
+  # Choose the trigger(s) that fit your deployment strategy. This template can be run
+  # manually from the GitHub Actions UI; uncomment the others to deploy automatically,
+  # for example on a merge to your main branch or on a release tag.
+  workflow_dispatch:
+  # push:
+  #   branches: [main]
+  # push:
+  #   tags: ['v*']
+
+env:
+  CLOUD_PROVIDER: ${{ secrets.CLOUD_PROVIDER }}
+  CLOUD_REGION: ${{ secrets.CLOUD_REGION }}
+  FLINK_API_KEY: ${{ secrets.FLINK_API_KEY }}
+  FLINK_API_SECRET: ${{ secrets.FLINK_API_SECRET }}
+  ORG_ID: ${{ secrets.ORG_ID }}
+  ENV_ID: ${{ secrets.ENV_ID }}
+  COMPUTE_POOL_ID: ${{ secrets.COMPUTE_POOL_ID }}
+  TARGET_CATALOG: ${{ secrets.TARGET_CATALOG }}
+  TARGET_DATABASE: ${{ secrets.TARGET_DATABASE }}
+  # Fixed here because they define what this pipeline deploys (and a push trigger cannot
+  # supply inputs); the manage workflow takes them as inputs instead.
+  APPLICATION_NAME: marketplace-analytics
+  STATEMENT_NAME: vendors-per-brand
+
+jobs:
+  test-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+          cache: maven
+
+      - name: Run local unit tests and integration tests against Confluent Cloud
+        run: ./mvnw -B --no-transfer-progress verify
+
+      - name: Deploy to Confluent Cloud
+        # --sql.current-catalog / --sql.current-database select the target environment and Kafka
+        # cluster (they are ordinary configuration options, like the connection settings).
+        # --on-conflict replace redeploys a changed pipeline under the same name; it requires
+        # --application-name. "Replace" deletes and recreates the statement, so a stateful
+        # pipeline restarts from its configured source offsets without resuming prior state
+        # (see the README CI/CD section).
+        run: >
+          java -jar target/flink-table-api-java-examples-1.0.jar
+          --statement-name "$STATEMENT_NAME"
+          --application-name "$APPLICATION_NAME"
+          --sql.current-catalog "$TARGET_CATALOG"
+          --sql.current-database "$TARGET_DATABASE"
+          --on-conflict replace
+
+      - name: Verify the deployed statement
+        # Submitting a background statement returns once Confluent Cloud accepts it, so
+        # list reports the statement and its phase for visibility in the log.
+        run: >
+          java -jar target/flink-table-api-java-examples-1.0.jar
+          list
+          --application-name "$APPLICATION_NAME"

--- a/.github/workflows-examples/manage.yml
+++ b/.github/workflows-examples/manage.yml
@@ -1,0 +1,70 @@
+# EXAMPLE WORKFLOW - copy this file to .github/workflows/ in your own repository.
+# It lives in workflows-examples/ because this examples repository does not manage
+# statements in a real Confluent Cloud environment. It runs the deployment JAR with one
+# of the plugin's built-in lifecycle actions (list/describe/resume/stop/delete) chosen by
+# the operator. See the README's CI/CD section for the deployment model and the required
+# secrets. The application name defaults to the one deploy.yml uses; override it per run.
+name: Manage Flink Statements
+
+on:
+  workflow_dispatch:
+    inputs:
+      action:
+        description: 'Action to perform'
+        required: true
+        type: choice
+        options:
+          - list
+          - describe
+          - resume
+          - stop
+          - delete
+      application-name:
+        description: 'Application the statement belongs to (set at deploy time)'
+        required: true
+        default: marketplace-analytics
+      statement-name:
+        description: 'Statement name set at deploy time, e.g. vendors-per-brand (leave empty for list to show all)'
+        required: false
+
+env:
+  CLOUD_PROVIDER: ${{ secrets.CLOUD_PROVIDER }}
+  CLOUD_REGION: ${{ secrets.CLOUD_REGION }}
+  FLINK_API_KEY: ${{ secrets.FLINK_API_KEY }}
+  FLINK_API_SECRET: ${{ secrets.FLINK_API_SECRET }}
+  ORG_ID: ${{ secrets.ORG_ID }}
+  ENV_ID: ${{ secrets.ENV_ID }}
+  COMPUTE_POOL_ID: ${{ secrets.COMPUTE_POOL_ID }}
+
+jobs:
+  manage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+          cache: maven
+
+      - name: Build
+        run: ./mvnw -B --no-transfer-progress -DskipTests package
+
+      - name: Run lifecycle action
+        # Inputs are passed via env, not interpolated into the script, so free-text input
+        # cannot inject shell commands. The command is built as an array so each argument
+        # stays a single word regardless of its content.
+        env:
+          ACTION: ${{ inputs.action }}
+          APPLICATION_NAME: ${{ inputs.application-name }}
+          STATEMENT_NAME: ${{ inputs.statement-name }}
+        # --statement-name is added only when set (list then covers all statements).
+        # --wait makes stop/resume/delete block until the target phase so the exit code
+        # reflects the outcome; list and describe ignore it.
+        run: |
+          args=("$ACTION" --application-name "$APPLICATION_NAME" --wait)
+          if [ -n "$STATEMENT_NAME" ]; then
+            args+=(--statement-name "$STATEMENT_NAME")
+          fi
+          java -jar target/flink-table-api-java-examples-1.0.jar "${args[@]}"

--- a/.github/workflows-examples/manage.yml
+++ b/.github/workflows-examples/manage.yml
@@ -6,6 +6,12 @@
 # secrets. The application name defaults to the one deploy.yml uses; override it per run.
 name: Manage Flink Statements
 
+# Name each run after the action and target so the runs list is distinguishable at a glance
+# (e.g. "stop on marketplace-analytics / vendors-per-brand"). The statement-name part is only
+# added when set, so "list" (which takes no statement) shows no dangling separator. Hyphenated
+# inputs use bracket syntax because a dot would be parsed as subtraction.
+run-name: "${{ inputs.action }} on ${{ inputs['application-name'] }}${{ inputs['statement-name'] != '' && format(' / {0}', inputs['statement-name']) || '' }}"
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows-examples/manage.yml
+++ b/.github/workflows-examples/manage.yml
@@ -67,4 +67,4 @@ jobs:
           if [ -n "$STATEMENT_NAME" ]; then
             args+=(--statement-name "$STATEMENT_NAME")
           fi
-          java -jar target/flink-table-api-java-examples-1.0.jar "${args[@]}"
+          java -cp target/flink-table-api-java-examples-1.0.jar io.confluent.flink.examples.table.Example_08_IntegrationAndDeployment "${args[@]}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+# Continuous integration for this repository.
+#
+# Runs entirely without Confluent Cloud connectivity: code format check (Spotless),
+# compilation, local unit tests on Apache Flink, and the fat JAR build.
+# Integration tests (*IT) require Confluent Cloud credentials and would fail without
+# them, so this workflow skips them explicitly with -DskipITs.
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+          cache: maven
+
+      - name: Build and test
+        run: ./mvnw -B --no-transfer-progress verify -DskipITs

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ target/
 *.DS_Store
 cloud.properties
 dependency-reduced-pom.xml
+*.env

--- a/README.md
+++ b/README.md
@@ -90,6 +90,20 @@ public static void main(String[] args) {
   // pipeline.execute().await();
 ```
 
+## Developer Journey
+
+The examples in this repository follow the journey of taking a table program from a first
+experiment all the way to a production deployment:
+
+| Stage | What you do | Where to look |
+|-------|-------------|---------------|
+| Get started | Configure a connection to Confluent Cloud and run a first program | `Example_00` - `Example_02`, [Getting Started](#getting-started) |
+| Build | Transform tables, build pipelines, work with data types, UDFs, and structured objects | `Example_03` - `Example_07`, `Example_09` - `Example_11`, `TableProgramTemplate` |
+| Test locally | Run unit tests on mock data, without Confluent Cloud connectivity | `src/test/java/`, [Testing Table Programs](#testing-table-programs) |
+| Test on Confluent Cloud | Run integration tests against the real service | `Example_08_IntegrationAndDeploymentIT`, [Testing Table Programs](#testing-table-programs) |
+| Deploy | Submit statements with deterministic names from a CI/CD pipeline | `Example_08_IntegrationAndDeployment`, [CI/CD with GitHub Actions](#cicd-with-github-actions) |
+| Operate | List, describe, stop, resume, and delete deployed statements | `.github/workflows-examples/manage.yml` |
+
 ## Getting Started
 
 ### Prerequisites
@@ -455,6 +469,105 @@ ConfluentSettings settings3 = ConfluentSettings.newBuilder()
     // Other required settings...
     .build();
 ```
+
+## Testing Table Programs
+
+Table programs can be tested in three tiers, from fastest feedback to highest fidelity:
+
+1. **Unit tests on plain logic.** UDFs and other business logic are plain Java classes and can be
+   tested with JUnit alone: no Apache Flink, no Confluent Cloud connectivity, and no artifact
+   upload required. See `Example_09_FunctionsTest`.
+2. **Local pipeline tests on Apache Flink.** Pipeline logic that is structured as
+   a function from input `Table`s to an output `Table` (see `VendorsPerBrand` in
+   `Example_08_IntegrationAndDeployment`) can be executed locally with mock data from
+   `fromValues()`, without Confluent Cloud connectivity. See
+   `Example_08_IntegrationAndDeploymentTest` and run with `./mvnw test`.
+3. **Integration tests against Confluent Cloud.** The same pipeline logic runs on the real
+   service with the exact Confluent semantics, on a Kafka-backed table that is made bounded with
+   dynamic options. See `Example_08_IntegrationAndDeploymentIT` and run with `./mvnw verify`.
+   These tests require the connection environment variables (see
+   [Via Environment Variables](#via-environment-variables)) plus `TARGET_CATALOG` (the name of
+   your Confluent Cloud environment) and `TARGET_DATABASE` (the name of a Kafka cluster with
+   write access), and fail fast when any are missing, so a CI pipeline cannot silently skip its
+   verification step and still report success. To build without Confluent Cloud credentials on
+   purpose, skip them explicitly: `./mvnw verify -DskipITs`.
+
+### How local testing works
+
+The Confluent plugin executes all statements on Confluent Cloud; it does not run them locally.
+Local tests therefore run on Apache Flink (planner, runtime, and an embedded mini-cluster), which
+this project adds as test-scoped dependencies.
+
+The plugin and the Apache Flink planner cannot share a runtime classpath: both register their
+Executor and Planner factories under the identifier `default`, and `TableEnvironment.create(...)` fails with
+`Multiple factories for identifier 'default'` if both are present. This project resolves the
+conflict with classpath exclusions in the `pom.xml`:
+
+- `./mvnw test` (surefire) excludes the Confluent plugin, so unit tests run on Apache Flink.
+- `./mvnw verify` (failsafe, test classes named `*IT`) excludes the Apache Flink planner, so
+  integration tests run against Confluent Cloud.
+
+Keep pipeline logic free of `io.confluent.flink.plugin` imports so that unit tests can execute it
+locally.
+
+NOTE: IDEs ignore these classpath exclusions, so run the tests via `./mvnw test` and
+`./mvnw verify` instead of the IDE's test runner. To use the IDE's test runner anyway, replicate
+the exclusion in the test's run configuration (IntelliJ IDEA: Modify options -> Modify classpath ->
+Exclude): exclude the `confluent-flink-table-api-java-plugin` JAR for unit tests, or the
+`flink-table-planner-loader` JAR for integration tests. For production projects, the cleaner
+structure is a multi-module build: one module contains the pipeline logic with only
+`flink-table-api-java` and the Apache Flink test dependencies, and another module adds the
+Confluent plugin and the deployment entrypoints.
+
+### Local testing limitations
+
+Running locally on Apache Flink is not identical to Confluent Cloud:
+
+- The `$rowtime` system column and other Confluent system columns do not exist locally.
+- There is no local catalog mirroring your Confluent Cloud schemas. Mock tables are declared
+  manually with `fromValues()` and must be kept in sync with the real schemas.
+- Confluent-specific SQL syntax (such as `DISTRIBUTED INTO ... BUCKETS`) and Confluent-provided
+  functions are not available.
+
+Local tests give fast feedback on transformation logic; integration tests against Confluent Cloud
+remain the source of truth.
+
+## CI/CD with GitHub Actions
+
+The repository contains workflows that show how a table program moves through a CI/CD pipeline:
+
+- `.github/workflows/ci.yml` runs in this repository on every pull request: code format check,
+  compilation, local unit tests, and the fat JAR build. It requires no Confluent Cloud
+  credentials.
+- `.github/workflows-examples/deploy.yml` is a template for your own repository: it runs the
+  integration tests against Confluent Cloud and then deploys the program by running its `main()`
+  method with `--statement-name`, `--application-name`, and `--on-conflict replace`. The statement
+  and application names are deployment configuration passed by the pipeline (not hardcoded in the
+  program), so the same name is used for deployment and for management; the application name is
+  prefixed to the statement name on submission (e.g. `marketplace-analytics-vendors-per-brand`).
+  Re-running with unchanged code is idempotent, and a changed pipeline replaces the existing
+  statement under the same name.
+
+  `--on-conflict replace` deletes the existing statement and submits a new one: the new statement
+  starts from its configured source offsets and does not resume the previous statement's state.
+  For stateless pipelines (filters, projections, routing) this has no effect on results. For
+  stateful pipelines (aggregations, joins, deduplication, including the aggregation in this
+  example) the new statement rebuilds its state by reprocessing from the configured start
+  position, so choose the redeploy timing and the source startup mode accordingly.
+- `.github/workflows-examples/manage.yml` is a template for explicit lifecycle operations. It runs
+  the same deployment JAR with one of the plugin's built-in actions (`list`, `describe`, `stop`,
+  `resume`, `delete`) as the first argument; the plugin executes the action instead of deploying,
+  so no separate program is needed. Deployment and lifecycle management are separate concerns;
+  removing code does not imply that a running statement should be stopped or deleted.
+
+The workflows authenticate via the environment variables described in
+[Via Environment Variables](#via-environment-variables), mapped from GitHub Actions secrets. The
+target environment and Kafka cluster are selected with the `sql.current-catalog` and
+`sql.current-database` configuration options: the deploy workflow passes them on the command line
+(from the `TARGET_CATALOG` and `TARGET_DATABASE` secrets), and the integration tests read those
+same variables. Because they are deployment configuration rather than source constants,
+staging-to-production promotion is a matter of running the same deploy job against different GitHub
+environments, each providing its own secrets and protection rules.
 
 ## Documentation for Confluent Utilities
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,8 @@
     <name>Apache Flink® Table API Java Examples on Confluent Cloud</name>
 
     <properties>
-        <flink.version>2.2.1</flink.version>
+        <flink.version>2.3.0</flink.version>
+        <!-- TODO: bump to the Confluent plugin release for Flink 2.3 before merging. -->
         <confluent-plugin.version>2.2-24</confluent-plugin.version>
         <target.java.version>17</target.java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -18,6 +19,9 @@
         <maven.compiler.target>${target.java.version}</maven.compiler.target>
         <log4j.version>2.26.0</log4j.version>
         <spotless.version>3.7.0</spotless.version>
+        <junit.version>5.12.2</junit.version>
+        <assertj.version>3.27.3</assertj.version>
+        <surefire.version>3.5.4</surefire.version>
     </properties>
 
     <repositories>
@@ -51,6 +55,40 @@
             <groupId>io.confluent.flink</groupId>
             <artifactId>confluent-flink-table-api-java-plugin</artifactId>
             <version>${confluent-plugin.version}</version>
+        </dependency>
+
+        <!-- Test dependencies for running table programs locally without Confluent Cloud
+             connectivity. The Apache Flink planner, runtime, and an embedded mini-cluster
+             (via flink-clients) execute pipeline logic on mock data in unit tests. -->
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-planner-loader</artifactId>
+            <version>${flink.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-runtime</artifactId>
+            <version>${flink.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-clients</artifactId>
+            <version>${flink.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>${assertj.version}</version>
+            <scope>test</scope>
         </dependency>
 
         <!-- Add logging framework, to produce console output when running in the IDE. -->
@@ -114,6 +152,45 @@
                         <phase>validate</phase>
                         <goals>
                             <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <!-- Unit tests (mvn test) run table programs locally on Apache Flink.
+                 The Confluent plugin and the Apache Flink planner both register their
+                 Executor/Planner factories under the identifier 'default', so they cannot share a
+                 runtime classpath. Unit tests therefore exclude the Confluent plugin.
+                 NOTE: IDEs ignore this exclusion; run tests via ./mvnw test instead. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${surefire.version}</version>
+                <configuration>
+                    <classpathDependencyExcludes>
+                        <classpathDependencyExclude>io.confluent.flink:confluent-flink-table-api-java-plugin</classpathDependencyExclude>
+                    </classpathDependencyExcludes>
+                </configuration>
+            </plugin>
+
+            <!-- Integration tests (mvn verify, classes named *IT) run against Confluent Cloud
+                 using the Confluent plugin and therefore exclude the Apache Flink planner instead.
+                 They fail fast when no Confluent Cloud credentials are configured; skip them
+                 explicitly with -DskipITs. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>${surefire.version}</version>
+                <configuration>
+                    <classpathDependencyExcludes>
+                        <classpathDependencyExclude>org.apache.flink:flink-table-planner-loader</classpathDependencyExclude>
+                    </classpathDependencyExcludes>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -11,8 +11,7 @@
 
     <properties>
         <flink.version>2.3.0</flink.version>
-        <!-- TODO: bump to the Confluent plugin release for Flink 2.3 before merging. -->
-        <confluent-plugin.version>2.2-24</confluent-plugin.version>
+        <confluent-plugin.version>2.3-1</confluent-plugin.version>
         <target.java.version>17</target.java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>${target.java.version}</maven.compiler.source>

--- a/src/main/java/io/confluent/flink/examples/table/Example_08_IntegrationAndDeployment.java
+++ b/src/main/java/io/confluent/flink/examples/table/Example_08_IntegrationAndDeployment.java
@@ -4,218 +4,106 @@ import io.confluent.flink.plugin.ConfluentSettings;
 import io.confluent.flink.plugin.ConfluentTools;
 
 import org.apache.flink.table.api.EnvironmentSettings;
+import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.TableResult;
-import org.apache.flink.types.Row;
-import org.apache.flink.util.CloseableIterator;
 
-import java.util.List;
-import java.util.UUID;
-import java.util.stream.Collectors;
-
+import static org.apache.flink.table.api.Expressions.$;
 import static org.apache.flink.table.api.Expressions.lit;
-import static org.apache.flink.table.api.Expressions.withAllColumns;
 
 /**
- * An example that illustrates how to embed a table program into a CI/CD pipeline for continuous
- * testing and rollout.
+ * An example that illustrates how to structure, test, and deploy a table program for production use
+ * in a CI/CD pipeline.
  *
- * <p>Because we cannot rely on production data in this example, the program sets up some
- * Kafka-backed tables with data during the {@code setup} phase.
+ * <p>The example separates two concerns that often end up entangled:
  *
- * <p>Afterward, the program can operate in two modes: one for integration testing ({@code test}
- * phase) and one for deployment ({@code deploy} phase).
+ * <ul>
+ *   <li>The pipeline logic in {@link VendorsPerBrand} is plain Table API code without any
+ *       Confluent-specific dependencies. It receives its input table as a parameter instead of
+ *       resolving it from a catalog. This makes the logic executable on Apache Flink in local unit
+ *       tests, where the input is mocked with {@code fromValues()} (see {@code
+ *       Example_08_IntegrationAndDeploymentTest}), as well as on Confluent Cloud for Apache Flink,
+ *       where the input is a Kafka-backed table (see {@code
+ *       Example_08_IntegrationAndDeploymentIT}).
+ *   <li>The {@link #main(String[])} method is the deployment entrypoint. It wires the pipeline to
+ *       Confluent Cloud and submits it as a long-running background statement.
+ * </ul>
  *
- * <p>A CI/CD workflow could execute the following:
+ * <p>The program is configured with {@link ConfluentSettings#fromArgs(String[])}, which reads
+ * configuration from command-line arguments, with environment variables as a fallback. This also
+ * enables the plugin's built-in CI/CD lifecycle actions: when the JAR is run with an action as the
+ * first argument ({@code list}, {@code describe}, {@code resume}, {@code stop}, or {@code delete}),
+ * the plugin executes the action and exits before the deployment logic runs, so the same JAR both
+ * deploys and manages (see {@code .github/workflows-examples/manage.yml}).
  *
- * <pre>
- *     export EXAMPLE_JAR=./target/flink-table-api-java-examples-1.0.jar
- *     export EXAMPLE_CLASS=io.confluent.flink.examples.table.Example_08_IntegrationAndDeployment
- *     java -jar $EXAMPLE_JAR $EXAMPLE_CLASS setup
- *     java -jar $EXAMPLE_JAR $EXAMPLE_CLASS test
- *     java -jar $EXAMPLE_JAR $EXAMPLE_CLASS deploy
- * </pre>
+ * <p>The statement name and application name are deployment configuration, not source constants:
+ * the pipeline provides them via {@code --statement-name} / {@code --application-name}, which keeps
+ * a single source of truth for both deploy and management and is required for the lifecycle actions
+ * (they read the name at startup, before {@code main()} runs). A program that submits several
+ * statements instead names each one in code via {@link
+ * ConfluentTools#setStatementName(TableEnvironment, String)}.
  *
- * <p>NOTE: This example requires write access to a Kafka cluster. Fill out the given variables
- * below with target catalog/database if this is fine for you.
+ * <p>Re-running the deployment with unchanged code is idempotent. When the pipeline changed, pass
+ * {@code --on-conflict replace} to replace the existing statement; see the README's CI/CD section
+ * for what that means for stateful pipelines. The README also covers configuration, environment
+ * promotion, and the full set of workflow steps.
  *
- * <p>ALSO NOTE: The example submits an unbounded background statement. Make sure to stop the
- * statement in the Web UI afterward to clean up resources.
+ * <p>NOTE: This example requires write access to a Kafka cluster, selected with the {@code
+ * sql.current-catalog} (environment name) and {@code sql.current-database} (Kafka cluster name)
+ * configuration options.
  *
- * <p>The complete CI/CD workflow performs the following steps:
- *
- * <ol>
- *   <li>Create Kafka table 'ProductsMock' and 'VendorsPerBrand'.
- *   <li>Fill Kafka table 'ProductsMock' with data from marketplace examples table 'products'.
- *   <li>Test the given SQL on a subset of data in 'ProductsMock' with the help of dynamic options.
- *   <li>Deploy an unbounded version of the tested SQL that write into 'VendorsPerBrand'.
- * </ol>
+ * <p>ALSO NOTE: The example submits an unbounded background statement. Use the lifecycle actions
+ * (see {@code .github/workflows-examples/manage.yml}) or the Web UI to stop and delete the
+ * statement afterward to clean up resources.
  */
 public class Example_08_IntegrationAndDeployment {
 
-    // Fill this with an environment you have write access to
-    static final String TARGET_CATALOG = "";
-
-    // Fill this with a Kafka cluster you have write access to
-    static final String TARGET_DATABASE = "";
-
-    // Fill this with names of the Kafka Topics you want to create
-    static final String SOURCE_TABLE = "ProductsMock";
+    // Name of the table that stores the results
     static final String TARGET_TABLE = "VendorsPerBrand";
 
-    // The following SQL will be tested on a finite subset of data before
-    // it gets deployed to production.
-    // In production, it will run on unbounded input.
-    // The '%s' parameterizes the SQL for testing.
-    static final String SQL =
-            "SELECT brand, COUNT(*) AS vendors FROM ProductsMock %s GROUP BY brand";
-
-    // All logic is defined in a main() method. It can run both in an IDE or CI/CD system.
-    public static void main(String[] args) throws Exception {
-        if (args.length == 0) {
-            throw new IllegalArgumentException(
-                    "No mode specified. Possible values are 'setup', 'test', or 'deploy'.");
-        }
-
-        EnvironmentSettings settings = ConfluentSettings.fromResource("/cloud.properties");
-        TableEnvironment env = TableEnvironment.create(settings);
-        env.useCatalog(TARGET_CATALOG);
-        env.useDatabase(TARGET_DATABASE);
-
-        String mode = args[0];
-        switch (mode) {
-            case "setup":
-                setupProgram(env);
-                break;
-            case "test":
-                testProgram(env);
-                break;
-            case "deploy":
-                deployProgram(env);
-                break;
-            default:
-                throw new IllegalArgumentException("Unknown mode: " + mode);
+    /**
+     * The pipeline logic under test: counts the number of vendors per brand.
+     *
+     * <p>This class must not reference any {@code io.confluent.flink.plugin} classes so that unit
+     * tests can run it on Apache Flink without the plugin on the classpath.
+     */
+    public static class VendorsPerBrand {
+        public static Table buildPipeline(Table products) {
+            return products.groupBy($("brand")).select($("brand"), lit(1).count().as("vendors"));
         }
     }
 
-    // --------------------------------------------------------------------------------------------
-    // Setup Phase
-    // --------------------------------------------------------------------------------------------
+    // The main() method performs the deployment, unless an action argument is present, in which
+    // case ConfluentSettings.fromArgs(...) below executes that action and exits before the rest
+    // of this method runs.
+    public static void main(String[] args) {
+        // All configuration comes from the deployment via fromArgs (with environment variables as
+        // a fallback): the connection settings, the statement and application names, and the
+        // target catalog and database (set with sql.current-catalog / sql.current-database). In
+        // GitHub Actions these map to repository or environment secrets; see the README.
+        EnvironmentSettings settings = ConfluentSettings.fromArgs(args);
+        TableEnvironment env = TableEnvironment.create(settings);
 
-    private static void setupProgram(TableEnvironment env) throws Exception {
-        System.out.println("Running setup...");
-
-        System.out.println("Creating table..." + SOURCE_TABLE);
-        // Create a mock table that has exactly the same schema as the example `products` table.
-        // The LIKE clause is very convenient for this task which is why we use SQL here.
-        // Since we use little data, a bucket of 1 is important to satisfy the `scan.bounded.mode`
-        // during testing.
+        System.out.println("Creating table... " + TARGET_TABLE);
+        // The pipeline owns its output table and creates it on the first deployment.
         env.executeSql(
                 String.format(
                         "CREATE TABLE IF NOT EXISTS `%s`\n"
-                                + "DISTRIBUTED INTO 1 BUCKETS\n"
-                                + "LIKE `examples`.`marketplace`.`products` (EXCLUDING OPTIONS)",
-                        SOURCE_TABLE));
-
-        System.out.println("Start filling table...");
-        // Let Flink copy generated data into the mock table. Note that the statement is unbounded
-        // and submitted as a background statement by default.
-        TableResult pipelineResult =
-                env.from("`examples`.`marketplace`.`products`")
-                        .select(withAllColumns())
-                        .insertInto(SOURCE_TABLE)
-                        .execute();
-
-        System.out.println("Waiting for at least 200 elements in table...");
-        // We start a second Flink statement for monitoring how the copying progresses
-        TableResult countResult = env.from(SOURCE_TABLE).select(lit(1).count()).as("c").execute();
-        // This waits for the condition to be met:
-        try (CloseableIterator<Row> iterator = countResult.collect()) {
-            while (iterator.hasNext()) {
-                Row row = iterator.next();
-                long count = row.getFieldAs("c");
-                if (count >= 200L) {
-                    System.out.println("200 elements reached. Stopping...");
-                    break;
-                }
-            }
-        }
-
-        // By using a closable iterator, the foreground statement will be stopped automatically when
-        // the iterator is closed. But the background statement still needs a manual stop.
-        ConfluentTools.stopStatement(pipelineResult);
-
-        System.out.println("Creating table..." + TARGET_TABLE);
-        // Create a table for storing the results after deployment.
-        env.executeSql(
-                String.format(
-                        "CREATE TABLE IF NOT EXISTS `%s` \n"
                                 + "(brand STRING, vendors BIGINT, PRIMARY KEY(brand) NOT ENFORCED)\n"
                                 + "DISTRIBUTED INTO 1 BUCKETS",
                         TARGET_TABLE));
-    }
 
-    // --------------------------------------------------------------------------------------------
-    // Test Phase
-    // --------------------------------------------------------------------------------------------
+        System.out.println("Deploying statement...");
+        // The same pipeline logic that was tested locally and against Confluent Cloud now runs
+        // unbounded on the continuously generated rows of the examples catalog.
+        Table products = env.from("`examples`.`marketplace`.`products`");
+        TableResult result =
+                VendorsPerBrand.buildPipeline(products).insertInto(TARGET_TABLE).execute();
 
-    private static void testProgram(TableEnvironment env) {
-        System.out.println("Running test...");
-
-        // Dynamic options allow influencing parts of a table scan. In this case, they define a
-        // range (from start offset '0' to end offset '100') how to read from Kafka. Effectively,
-        // they make the table bounded. If all tables are finite, the statement can terminate.
-        // This allows us to run checks on the result.
-        String dynamicOptions =
-                "/*+ OPTIONS(\n"
-                        + "'scan.startup.mode' = 'specific-offsets',\n"
-                        + "'scan.startup.specific-offsets' = 'partition: 0, offset: 0',\n"
-                        + "'scan.bounded.mode' = 'specific-offsets',\n"
-                        + "'scan.bounded.specific-offsets' = 'partition: 0, offset: 100'\n"
-                        + ") */";
-
-        System.out.println("Requesting test data...");
-        TableResult result = env.executeSql(String.format(SQL, dynamicOptions));
-        List<Row> rows = ConfluentTools.collectMaterialized(result);
-
+        // Print the final submitted name (application prefix included) for use with the lifecycle
+        // actions. If no name was configured, the plugin generates one, which is not addressable
+        // for later management; CI/CD deployments should always pass --statement-name.
         System.out.println(
-                "Test data:\n"
-                        + rows.stream().map(Row::toString).collect(Collectors.joining("\n")));
-
-        // Use the testing framework of your choice and add checks to verify the
-        // correctness of the test data
-        boolean testSuccessful =
-                rows.stream()
-                        .map(r -> r.<String>getFieldAs("brand"))
-                        .anyMatch(brand -> brand.equals("Apple"));
-        if (testSuccessful) {
-            System.out.println("Success. Ready for deployment.");
-        } else {
-            throw new IllegalStateException("Test was not successful");
-        }
-    }
-
-    // --------------------------------------------------------------------------------------------
-    // Deploy Phase
-    // --------------------------------------------------------------------------------------------
-
-    private static void deployProgram(TableEnvironment env) {
-        System.out.println("Running deploy...");
-
-        // It is possible to give a better statement name for deployment but make sure that the name
-        // is unique across environment and region.
-        String statementName = "vendors-per-brand-" + UUID.randomUUID();
-        env.getConfig().set("client.statement-name", statementName);
-
-        // Execute the SQL without dynamic options.
-        // The result is unbounded and piped into the target table.
-        TableResult insertIntoResult =
-                env.sqlQuery(String.format(SQL, "")).insertInto(TARGET_TABLE).execute();
-
-        // The API might add suffixes to manual statement names such as '-sql' or '-api'.
-        // For the final submitted name, use the provided tools.
-        String finalName = ConfluentTools.getStatementName(insertIntoResult);
-
-        System.out.println("Statement has been deployed as: " + finalName);
+                "Statement has been deployed as: " + ConfluentTools.getStatementName(result));
     }
 }

--- a/src/test/java/io/confluent/flink/examples/table/Example_08_IntegrationAndDeploymentIT.java
+++ b/src/test/java/io/confluent/flink/examples/table/Example_08_IntegrationAndDeploymentIT.java
@@ -10,6 +10,7 @@ import org.apache.flink.table.api.TableResult;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.CloseableIterator;
 
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -70,10 +71,15 @@ class Example_08_IntegrationAndDeploymentIT {
         // The LIKE clause is very convenient for this task which is why we use SQL here.
         // Since we use little data, a bucket of 1 is important to satisfy the
         // `scan.bounded.mode` during testing.
+        // The fill statement writes with exactly-once semantics, so records only become visible to
+        // read-committed consumers once a checkpoint commits (~1 min on Confluent Cloud). This test
+        // reads the freshly filled data well within that interval, so it reads uncommitted records;
+        // committed durability is not what this pipeline test verifies.
         env.executeSql(
                 String.format(
                         "CREATE TABLE IF NOT EXISTS `%s`\n"
                                 + "DISTRIBUTED INTO 1 BUCKETS\n"
+                                + "WITH ('kafka.consumer.isolation-level' = 'read-uncommitted')\n"
                                 + "LIKE `examples`.`marketplace`.`products` (EXCLUDING OPTIONS)",
                         SOURCE_TABLE));
 
@@ -185,5 +191,14 @@ class Example_08_IntegrationAndDeploymentIT {
         // The examples data generator produces a fixed set of brands. Checking for a known one
         // guards against reading the wrong data, not just producing plausible-looking rows.
         assertThat(rows).extracting(row -> row.<String>getFieldAs("brand")).contains("Apple");
+    }
+
+    @AfterAll
+    // Drop the mock table so the run does not leak a topic into the environment. Runs even when a
+    // test fails, so a failed run cleans up after itself too.
+    static void dropMockTable() {
+        if (env != null) {
+            env.executeSql(String.format("DROP TABLE IF EXISTS `%s`", SOURCE_TABLE));
+        }
     }
 }

--- a/src/test/java/io/confluent/flink/examples/table/Example_08_IntegrationAndDeploymentIT.java
+++ b/src/test/java/io/confluent/flink/examples/table/Example_08_IntegrationAndDeploymentIT.java
@@ -1,0 +1,189 @@
+package io.confluent.flink.examples.table;
+
+import io.confluent.flink.plugin.ConfluentPluginOptions;
+import io.confluent.flink.plugin.ConfluentSettings;
+import io.confluent.flink.plugin.ConfluentTools;
+
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.api.TableResult;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.CloseableIterator;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.table.api.Expressions.lit;
+import static org.apache.flink.table.api.Expressions.withAllColumns;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Integration tests for the pipeline logic of {@link Example_08_IntegrationAndDeployment}, executed
+ * against Confluent Cloud.
+ *
+ * <p>While the unit tests (see {@code Example_08_IntegrationAndDeploymentTest}) verify the logic
+ * locally, these tests verify it on the real service: the exact Confluent SQL semantics, the
+ * Confluent catalog, and Kafka-backed tables.
+ *
+ * <p>The tests run during {@code ./mvnw verify} and fail fast when the required environment
+ * variables are not set, so a CI pipeline cannot silently skip its verification step and still
+ * report success. Builds without Confluent Cloud credentials skip them with {@code ./mvnw verify
+ * -DskipITs}. They require the standard connection variables (see the README's "Via Environment
+ * Variables" section) plus TARGET_CATALOG and TARGET_DATABASE pointing to an environment and Kafka
+ * cluster with write access.
+ *
+ * <p>Because we cannot rely on production data in this example, the test fixture creates a mock
+ * Kafka-backed table and fills it with data from the marketplace examples table. Dynamic options
+ * then make the table bounded, so the pipeline terminates and its result can be asserted.
+ *
+ * <p>NOTE: Running from the IDE needs the opposite classpath exclusion from the unit tests (the
+ * {@code flink-table-planner-loader} JAR) plus the environment variables in the run configuration;
+ * see the README's testing section.
+ */
+class Example_08_IntegrationAndDeploymentIT {
+
+    // Name of the mock Kafka topic that emulates the production input
+    static final String SOURCE_TABLE = "ProductsMock";
+
+    static TableEnvironment env;
+
+    @BeforeAll
+    // The timeout runs the setup in a separate thread so that it can be interrupted even while
+    // blocked on statement results, e.g. when the compute pool has no capacity for the fill
+    // statement. Without it, a stuck setup would hang until the CI job timeout.
+    @Timeout(value = 15, unit = TimeUnit.MINUTES, threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
+    static void setUpMockTable() throws Exception {
+        requireEnvironment();
+        env = TableEnvironment.create(ConfluentSettings.fromGlobalVariables());
+        env.useCatalog(System.getenv("TARGET_CATALOG"));
+        env.useDatabase(System.getenv("TARGET_DATABASE"));
+
+        System.out.println("Creating table... " + SOURCE_TABLE);
+        // Create a mock table that has exactly the same schema as the example `products` table.
+        // The LIKE clause is very convenient for this task which is why we use SQL here.
+        // Since we use little data, a bucket of 1 is important to satisfy the
+        // `scan.bounded.mode` during testing.
+        env.executeSql(
+                String.format(
+                        "CREATE TABLE IF NOT EXISTS `%s`\n"
+                                + "DISTRIBUTED INTO 1 BUCKETS\n"
+                                + "LIKE `examples`.`marketplace`.`products` (EXCLUDING OPTIONS)",
+                        SOURCE_TABLE));
+
+        System.out.println("Start filling table...");
+        // Let Flink copy generated data into the mock table. Note that the statement is
+        // unbounded and submitted as a background statement by default.
+        TableResult pipelineResult =
+                env.from("`examples`.`marketplace`.`products`")
+                        .select(withAllColumns())
+                        .insertInto(SOURCE_TABLE)
+                        .execute();
+
+        long count = 0;
+        try {
+            System.out.println("Waiting for at least 200 elements in table...");
+            // A second Flink statement monitors how the copying progresses. The foreground
+            // statement is stopped automatically when its iterator is closed.
+            TableResult countResult =
+                    env.from(SOURCE_TABLE).select(lit(1).count()).as("c").execute();
+            try (CloseableIterator<Row> iterator = countResult.collect()) {
+                while (count < 200L && iterator.hasNext()) {
+                    count = iterator.next().getFieldAs("c");
+                }
+            }
+        } finally {
+            // The fill statement is unbounded and must always be cleaned up, even when the wait
+            // above fails, as it would otherwise keep running and consuming CFUs. It is also
+            // deleted rather than just stopped: it gets a random name on every run, and stopped
+            // statements would accumulate in the environment.
+            String fillStatement = ConfluentTools.getStatementName(pipelineResult);
+            ConfluentTools.stopStatement(env, fillStatement);
+            ConfluentTools.deleteStatement(env, fillStatement);
+        }
+        if (count < 200L) {
+            fail(
+                    "The mock table only reached "
+                            + count
+                            + " elements before the monitoring statement terminated.");
+        }
+        System.out.println("200 elements reached.");
+    }
+
+    // Fails fast with a clear message instead of skipping, so that a CI pipeline with missing
+    // secrets cannot report a successful verification that never ran. The connection variable
+    // names come from ConfluentPluginOptions, so the list cannot drift from the plugin contract.
+    private static void requireEnvironment() {
+        List<String> required = new ArrayList<>();
+        // A properties file referenced via FLINK_PROPERTIES is a valid alternative to the
+        // discrete connection variables (see the README's "Configuration" section).
+        if (isBlank(System.getenv(ConfluentPluginOptions.VAR_FLINK_PROPERTIES))) {
+            required.add(ConfluentPluginOptions.VAR_CLOUD_PROVIDER);
+            required.add(ConfluentPluginOptions.VAR_CLOUD_REGION);
+            required.add(ConfluentPluginOptions.VAR_FLINK_API_KEY);
+            required.add(ConfluentPluginOptions.VAR_FLINK_API_SECRET);
+            required.add(ConfluentPluginOptions.VAR_ORG_ID);
+            required.add(ConfluentPluginOptions.VAR_ENV_ID);
+            required.add(ConfluentPluginOptions.VAR_COMPUTE_POOL_ID);
+        }
+        required.add("TARGET_CATALOG");
+        required.add("TARGET_DATABASE");
+        List<String> missing =
+                required.stream()
+                        .filter(name -> isBlank(System.getenv(name)))
+                        .collect(Collectors.toList());
+        if (!missing.isEmpty()) {
+            fail(
+                    "Integration tests verify the pipeline against Confluent Cloud and require the"
+                            + " environment variables "
+                            + missing
+                            + ". Set them (see the README section 'Via Environment Variables') or"
+                            + " skip the integration tests explicitly with -DskipITs.");
+        }
+    }
+
+    private static boolean isBlank(String value) {
+        return value == null || value.isBlank();
+    }
+
+    @Test
+    void countsVendorsPerBrandOnBoundedData() {
+        // Dynamic options allow influencing parts of a table scan. In this case, they define a
+        // range (from start offset '0' to end offset '100') how to read from Kafka. Effectively,
+        // they make the table bounded. If all tables are finite, the statement can terminate.
+        // This allows us to run checks on the result.
+        Table boundedProducts =
+                env.sqlQuery(
+                        String.format(
+                                "SELECT * FROM `%s` /*+ OPTIONS(\n"
+                                        + "'scan.startup.mode' = 'specific-offsets',\n"
+                                        + "'scan.startup.specific-offsets' = 'partition: 0, offset: 0',\n"
+                                        + "'scan.bounded.mode' = 'specific-offsets',\n"
+                                        + "'scan.bounded.specific-offsets' = 'partition: 0, offset: 100'\n"
+                                        + ") */",
+                                SOURCE_TABLE));
+
+        // The exact same pipeline logic that the unit tests run locally
+        Table result =
+                Example_08_IntegrationAndDeployment.VendorsPerBrand.buildPipeline(boundedProducts);
+
+        List<Row> rows = ConfluentTools.collectMaterialized(result.execute());
+
+        assertThat(rows).isNotEmpty();
+        assertThat(rows)
+                .allSatisfy(
+                        row -> {
+                            assertThat(row.<String>getFieldAs("brand")).isNotBlank();
+                            assertThat(row.<Long>getFieldAs("vendors")).isPositive();
+                        });
+        // The examples data generator produces a fixed set of brands. Checking for a known one
+        // guards against reading the wrong data, not just producing plausible-looking rows.
+        assertThat(rows).extracting(row -> row.<String>getFieldAs("brand")).contains("Apple");
+    }
+}

--- a/src/test/java/io/confluent/flink/examples/table/Example_08_IntegrationAndDeploymentTest.java
+++ b/src/test/java/io/confluent/flink/examples/table/Example_08_IntegrationAndDeploymentTest.java
@@ -1,0 +1,108 @@
+package io.confluent.flink.examples.table;
+
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.EnvironmentSettings;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.types.Row;
+import org.apache.flink.types.RowKind;
+import org.apache.flink.util.CloseableIterator;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.apache.flink.table.api.Expressions.row;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for the pipeline logic of {@link Example_08_IntegrationAndDeployment}.
+ *
+ * <p>These tests run entirely locally on Apache Flink with mock data from {@code fromValues()}. No
+ * Confluent Cloud connectivity, credentials, or compute pool are required, which makes them
+ * suitable for fast feedback during development and for CI runs on pull requests.
+ *
+ * <p>NOTE: The Confluent plugin and the Apache Flink planner cannot share a runtime classpath (both
+ * register Executor and Planner factories under the identifier 'default'), so these tests must be
+ * executed via {@code ./mvnw test}, where the surefire configuration excludes the plugin. Running
+ * them directly from the IDE fails with "Multiple factories for identifier 'default'"; see the
+ * README's testing section for the IDE run-configuration setup.
+ *
+ * <p>ALSO NOTE: Running locally on Apache Flink is not identical to Confluent Cloud.
+ * Confluent-specific features such as the {@code $rowtime} system column, the Confluent catalog,
+ * and Confluent SQL extensions are not available locally. Use the integration tests (see {@code
+ * Example_08_IntegrationAndDeploymentIT}) to verify behavior against the real service.
+ */
+class Example_08_IntegrationAndDeploymentTest {
+
+    private static Table mockProducts(TableEnvironment env) {
+        return env.fromValues(
+                DataTypes.ROW(
+                        DataTypes.FIELD("name", DataTypes.STRING()),
+                        DataTypes.FIELD("brand", DataTypes.STRING())),
+                row("MacBook", "Apple"),
+                row("iPhone", "Apple"),
+                row("Galaxy", "Samsung"));
+    }
+
+    @Test
+    void countsVendorsPerBrandInBatchMode() throws Exception {
+        // Batch mode computes the final result over the finite mock data, which makes
+        // assertions straightforward.
+        TableEnvironment env = TableEnvironment.create(EnvironmentSettings.inBatchMode());
+
+        Table result =
+                Example_08_IntegrationAndDeployment.VendorsPerBrand.buildPipeline(
+                        mockProducts(env));
+
+        assertThat(collectRows(result))
+                .containsExactlyInAnyOrder(Row.of("Apple", 2L), Row.of("Samsung", 1L));
+    }
+
+    @Test
+    void countsVendorsPerBrandInStreamingMode() throws Exception {
+        // Streaming mode emits a changelog: an insert for the first product of a brand,
+        // followed by update_before/update_after pairs as more products arrive. This mirrors
+        // how the statement behaves on Confluent Cloud.
+        TableEnvironment env = TableEnvironment.create(EnvironmentSettings.inStreamingMode());
+
+        Table result =
+                Example_08_IntegrationAndDeployment.VendorsPerBrand.buildPipeline(
+                        mockProducts(env));
+
+        List<Row> changelog = collectRows(result);
+        assertThat(materialize(changelog))
+                .containsExactlyInAnyOrder(Row.of("Apple", 2L), Row.of("Samsung", 1L));
+    }
+
+    private static List<Row> collectRows(Table table) throws Exception {
+        List<Row> rows = new ArrayList<>();
+        try (CloseableIterator<Row> iterator = table.execute().collect()) {
+            iterator.forEachRemaining(rows::add);
+        }
+        return rows;
+    }
+
+    // Applies the changelog to derive the final result, similar to what
+    // ConfluentTools.collectMaterialized() does for statements running on Confluent Cloud.
+    // Rows are copied so that the caller's changelog is left untouched.
+    private static List<Row> materialize(List<Row> changelog) {
+        List<Row> state = new ArrayList<>();
+        for (Row row : changelog) {
+            Row copy = Row.copy(row);
+            copy.setKind(RowKind.INSERT);
+            switch (row.getKind()) {
+                case INSERT:
+                case UPDATE_AFTER:
+                    state.add(copy);
+                    break;
+                case UPDATE_BEFORE:
+                case DELETE:
+                    state.remove(copy);
+                    break;
+            }
+        }
+        return state;
+    }
+}

--- a/src/test/java/io/confluent/flink/examples/table/Example_09_FunctionsTest.java
+++ b/src/test/java/io/confluent/flink/examples/table/Example_09_FunctionsTest.java
@@ -1,0 +1,43 @@
+package io.confluent.flink.examples.table;
+
+import org.apache.flink.api.common.functions.util.ListCollector;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for the User-Defined Functions of {@link Example_09_Functions}.
+ *
+ * <p>UDFs are plain Java classes, so their logic can be tested with JUnit alone: no Apache Flink,
+ * no Confluent Cloud connectivity, and no artifact upload are required. This is the fastest test
+ * tier and should cover the bulk of a UDF's business logic before it is registered and exercised on
+ * Confluent Cloud.
+ */
+class Example_09_FunctionsTest {
+
+    @Test
+    void customTaxReturnsRatePerLocation() {
+        Example_09_Functions.CustomTax tax = new Example_09_Functions.CustomTax();
+
+        assertThat(tax.eval("USA")).isEqualTo(10);
+        assertThat(tax.eval("EU")).isEqualTo(5);
+        assertThat(tax.eval("Mars")).isEqualTo(0);
+    }
+
+    @Test
+    void explodeEmitsOneRowPerElement() {
+        Example_09_Functions.Explode explode = new Example_09_Functions.Explode();
+
+        // Table functions emit rows via a collector, which tests can replace with a list
+        List<String> collected = new ArrayList<>();
+        explode.setCollector(new ListCollector<>(collected));
+
+        explode.eval(List.of("Apples", "Bananas"));
+
+        assertThat(collected).containsExactly("Apples", "Bananas");
+    }
+}


### PR DESCRIPTION
Restructures the integration and deployment example around a realistic developer workflow and adds local testing and CI/CD lifecycle management:

- The pipeline logic of Example_08 is now a plugin-free function that is unit tested locally on Apache Flink with mock data from fromValues(), without Confluent Cloud connectivity. The Confluent plugin and the OSS planner both register engine factories under the identifier 'default' and cannot share a runtime classpath, so surefire excludes the plugin and failsafe excludes the OSS planner (documented in the README, including IDE run-configuration setup).
- New integration tests (*IT) run the same pipeline logic against Confluent Cloud on a bounded mock table. They fail fast with a clear message when the required environment variables are missing, so a CI pipeline (e.g. a deploy pipeline with a misconfigured secret) cannot silently skip its verification step and still report success; builds without credentials skip them explicitly with -DskipITs. The required variable names are taken from ConfluentPluginOptions so the check cannot drift from the plugin contract, and a FLINK_PROPERTIES-based configuration is accepted as an alternative. The fixture has a timeout, validates the row threshold was reached, and always stops and deletes its fill statement.
- Example_08's main() is reduced to a deployment entrypoint: configuration via environment variables, a deterministic statement name set through the typed ConfluentPluginOptions.CLIENT_STATEMENT_NAME option, idempotent re-runs, and rejection of stale mode arguments.
- New Example_12_StatementLifecycle performs status/stop/resume/delete on deployed statements by name.
- New CI workflow (format check, compile, local tests, fat JAR; no credentials required) and example deploy/manage workflows under .github/workflows-examples/ for use in downstream projects. The manage workflow passes inputs via quoted environment variables to avoid script injection.
- README gains a developer journey overview, a testing section covering the three test tiers and the Apache Flink (local) limitations, and CI/CD guidance.

Verified: ./mvnw clean verify -DskipITs passes offline (4 unit tests green), verify without credentials fails fast with the expected message, the shaded JAR is unaffected by the test dependencies (no OSS planner classes or service entries), and the integration test has been executed successfully against a live Confluent Cloud environment.