### PR TITLE
Add log4j2 configuration for console logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2026-07-01
+
+### Features and Fixes
+
+- Added `log4j2.properties` with default logging configuration.
+
 ## 2026-04-15
 
 ### Features and Fixes

--- a/src/main/resources/log4j2.properties
+++ b/src/main/resources/log4j2.properties
@@ -6,9 +6,12 @@ appender.console.target = SYSTEM_OUT
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{HH:mm:ss.SSS} %-5level %logger{36} - %msg%n
 
-# Mute Flink's own chatter; raise to INFO if you want it.
-rootLogger.level = WARN
+rootLogger.level = INFO
 rootLogger.appenderRef.console.ref = console
+
+# Mute Flink's own chatter; raise to INFO if you want it.
+logger.flink.name = org.apache.flink
+logger.flink.level = WARN
 
 # Set log level for Confluent Flink plugin
 logger.confluent.name = io.confluent.flink.plugin

--- a/src/main/resources/log4j2.properties
+++ b/src/main/resources/log4j2.properties
@@ -1,0 +1,15 @@
+status = warn
+
+appender.console.type = Console
+appender.console.name = console
+appender.console.target = SYSTEM_OUT
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d{HH:mm:ss.SSS} %-5level %logger{36} - %msg%n
+
+# Mute Flink's own chatter; raise to INFO if you want it.
+rootLogger.level = WARN
+rootLogger.appenderRef.console.ref = console
+
+# Set log level for Confluent Flink plugin
+logger.confluent.name = io.confluent.flink.plugin
+logger.confluent.level = INFO


### PR DESCRIPTION
## What is the purpose of the change

The examples had no logging configuration, so Log4j2 fell back to its default unstructured console output . This adds a `log4j2.properties` that sends structured output to the console, mutes Flink's own logging by default, and surfaces the Confluent Flink plugin logs at `INFO`.

## Brief change log

- Added `src/main/resources/log4j2.properties` with a console appender using a timestamped `PatternLayout`.
- Set `rootLogger` level to `WARN` to suppress Flink's default chatter.
- Set `io.confluent.flink.plugin` logger to `INFO` to keep plugin logs visible.