### PR TITLE
Add @confluentinc/flink-table-api to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*	@confluentinc/flink-sql
+*	@confluentinc/flink-sql @confluentinc/flink-table-api


### PR DESCRIPTION
## Summary
Extends the repository's `CODEOWNERS` to include the `@confluentinc/flink-table-api` team alongside the existing `@confluentinc/flink-sql` team, so both teams are requested as code owners for changes across the repo.

## Change
```
- *  @confluentinc/flink-sql
+ *  @confluentinc/flink-sql @confluentinc/flink-table-api
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)